### PR TITLE
Migrate from git packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@
         { name = "Gregory Bell" }
     ]
 
-    version = "4.0.4"
+    version = "4.0.5"
     requires-python = ">=3.10.0"
 
 [tool.pyright]

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -1,6 +1,6 @@
-git+https://github.com/gregbell26/HybridJsonTestRunner@0.7.0
+HybridJSONTestRunner==0.7.3
 dill==0.3.6
-Better-PyUnit-Format==0.2.0
+Better-PyUnit-Format==0.2.3
 schema==0.7.5
 requests==2.31.0
 tomli==2.0.1

--- a/tests/testStudentCreateGradescopeUpload.py
+++ b/tests/testStudentCreateGradescopeUpload.py
@@ -1,4 +1,5 @@
 import os
+from io import StringIO
 import random
 import shutil
 import string
@@ -33,7 +34,8 @@ class TestStudentCreateGradescopeUpload(unittest.TestCase):
             if os.path.isfile(file) and file[-4:] == ".zip":
                 os.remove(file)
 
-    def testAddFolderToZipOnePy(self):
+    @patch('sys.stdout', new_callable=StringIO)
+    def testAddFolderToZipOnePy(self, _):
         zipMock = MagicMock(spec=zipfile.ZipFile)
 
         createGradescopeUpload.addFolderToZip(zipMock, self.STUDENT_WORK_FOLDER)
@@ -43,7 +45,8 @@ class TestStudentCreateGradescopeUpload(unittest.TestCase):
         writeMock.assert_called_once()
         writeMock.assert_called_with(os.path.join(self.STUDENT_WORK_FOLDER, "submission.py"))
 
-    def testAddFolderToZipDataFilesOnePy(self):
+    @patch('sys.stdout', new_callable=StringIO)
+    def testAddFolderToZipDataFilesOnePy(self, _):
         for _ in range(10):
             randomName = "".join([random.choice(string.ascii_lowercase) for _ in range(10)]) + ".dat"
 
@@ -60,7 +63,8 @@ class TestStudentCreateGradescopeUpload(unittest.TestCase):
         writeMock.assert_called_with(os.path.join(self.STUDENT_WORK_FOLDER, "submission.py"))
 
     @patch("create_gradescope_upload.ZipFile")
-    def testGenerateZipFileOnePy(self, zipMock):
+    @patch('sys.stdout', new_callable=StringIO)
+    def testGenerateZipFileOnePy(self, _, zipMock):
         zipFileMock = MagicMock()
         zipMock.return_value.__enter__ = zipFileMock
 
@@ -72,7 +76,8 @@ class TestStudentCreateGradescopeUpload(unittest.TestCase):
         writeMock.assert_called_with("submission.py")
 
     @patch("create_gradescope_upload.ZipFile")
-    def testGenerateZipFileDataFilesOnePy(self, zipMock):
+    @patch('sys.stdout', new_callable=StringIO)
+    def testGenerateZipFileDataFilesOnePy(self, _, zipMock):
         for _ in range(10):
             randomName = "".join([random.choice(string.ascii_lowercase) for _ in range(10)]) + ".dat"
 

--- a/tests/testStudentTestMyWork.py
+++ b/tests/testStudentTestMyWork.py
@@ -72,7 +72,8 @@ class TestStudentTestMyWork(unittest.TestCase):
 
         self.assertTrue(result)
 
-    def testCleanPrevSubmission(self):
+    @patch('sys.stdout', new_callable=StringIO)
+    def testCleanPrevSubmission(self, _):
         for _ in range(10):
             fileName = "".join([random.choice(string.ascii_letters) for _ in range(10)]) + ".zip"
 
@@ -150,12 +151,21 @@ class TestStudentTestMyWork(unittest.TestCase):
     def testMissingPackage(self, _):
         self.assertIsNone(importlib.util.find_spec("pip_install_test"))
 
-        testMyWork.verifyRequiredPackages({"pip_install_test": "pip-install-test"})
+        res = testMyWork.verifyRequiredPackages({"pip_install_test": "pip-install-test"})
 
         self.assertIsNotNone(importlib.util.find_spec("pip_install_test"))
 
-        subprocess.run([sys.executable, "-m", "pip", "uninstall", "-y", "pip-install-test"])
+        self.assertTrue(res)
+
+        subprocess.run([sys.executable, "-m", "pip", "uninstall", "-y", "pip-install-test"], stdout=subprocess.DEVNULL)
         
+    @patch('sys.stdout', new_callable=StringIO)
+    def testPackageDoesNotExist(self, _):
+        self.assertIsNone(importlib.util.find_spec("this_package_doesnt_exist"))
+
+        res = testMyWork.verifyRequiredPackages({"this_package_doesnt_exist": "this_package_doesnt_exist"})
+
+        self.assertFalse(res)
 
     @patch('sys.stdout', new_callable=StringIO)
     def testPackagesPresent(self, _):


### PR DESCRIPTION
Use pypi for all packages
Make feedback a bit more readable for students when pip install fails via test_my_work
Reattempt install with `break-system-packages` if primary install fails (this is not idea but is better than making the students use virtual environments.
Make unit tests a bit less chatty