### PR TITLE
Add Prompt to Fix Working Directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@
         { name = "Gregory Bell" }
     ]
 
-    version = "4.0.5"
+    version = "4.0.6"
     requires-python = ">=3.10.0"
 
 [tool.pyright]

--- a/source/utils/student/test_my_work.py
+++ b/source/utils/student/test_my_work.py
@@ -166,10 +166,24 @@ def verifyPythonVersion(minVersion: Tuple[int, int], pythonVersionTuple: Tuple[i
         return False
 
     return True
-
+    
+def verifyWorkingDirectory(expectedPath: str) -> bool:
+    """
+    Checks if the working directory is the same as the "test_my_work.py" file.
+    
+    If not, the program is stopped before unknown errors occur."""
+    
+    if os.getcwd() != expectedPath:
+        printErrorMessage("Working Directory Error", f"Try using 'cd {expectedPath}' to set the correct directory to your project's path or ask a TA for assistance.")
+        return False
+    return True
+    
 
 if __name__ == "__main__":
     if not verifyPythonVersion(MIN_VERSION, sys.version_info):  # type: ignore
+        sys.exit(1)
+        
+    if not verifyWorkingDirectory(os.path.abspath(__file__)):
         sys.exit(1)
 
     cleanPreviousSubmissions(".")

--- a/tests/testStudentTestMyWork.py
+++ b/tests/testStudentTestMyWork.py
@@ -184,3 +184,10 @@ class TestStudentTestMyWork(unittest.TestCase):
         self.assertTrue(testMyWork.verifyPythonVersion((3, 11), (3, 11, 2, 'final', 0)))
         self.assertTrue(testMyWork.verifyPythonVersion((3, 11), (3, 12, 2, 'final', 0)))
 
+    @patch('sys.stdout', new_callable=StringIO)
+    def testWorkingDirectoryIncorrect(self, _):
+        self.assertFalse(testMyWork.verifyWorkingDirectory("./sandbox"))
+       
+    @patch('sys.stdout', new_callable=StringIO)
+    def testWorkingDirectoryIsCorrect(self, _):
+        self.assertTrue(testMyWork.verifyWorkingDirectory(os.getcwd()))


### PR DESCRIPTION
Checks if the working directory is the same as the "test_my_work.py" file. If not, the program is stopped before unknown errors occur.

If Working Directory is correct, nothing occurs. Else, the script is terminated before the subprocess is called or other errors occur and the student is prompted to change working directory through the terminal with a suggested path.