### PR TITLE
Fix GS forward crash

### DIFF
--- a/source/autograder_cli/run_gradescope.py
+++ b/source/autograder_cli/run_gradescope.py
@@ -71,6 +71,14 @@ class GradescopeAutograderCLI(AutograderCLITool):
             autograderResults['output'] += f"Score has been set to a floor of 0 to ensure no negative scores.\n"
             autograderResults['score'] = 0
 
+        max_score = self.config.config.max_score if self.config.config.allow_extra_credit else self.config.config.perfect_score
+
+        if autograderResults["score"] > max_score:
+            autograderResults["output"] += f"Score has been capped to {max_score}.\n"
+            autograderResults["score"] = max_score
+
+
+
     def configure_options(self):  # pragma: no cover
         self.parser.add_argument("--results-location", default="/autograder/results/results.json",
                                  help="The location for the autograder JSON results")

--- a/source/autograder_cli/run_gradescope.py
+++ b/source/autograder_cli/run_gradescope.py
@@ -46,7 +46,11 @@ class GradescopeAutograderCLI(AutograderCLITool):
              if 'results' in previousSubmissionMetadata.keys() and "score" in previousSubmissionMetadata["results"].keys()
              ]
 
-        autograderResults['output'] = f"Submission {len(validSubmissions) + 1} of {submissionLimit}.\n"
+
+        if self.config.config.enforce_submission_limit:
+            autograderResults['output'] = f"Submission {len(validSubmissions) + 1} of {submissionLimit}.\n"
+        else:
+            autograderResults['output'] = ""
 
         validSubmissions.append(autograderResults)
 

--- a/source/autograder_platform/config/Config.py
+++ b/source/autograder_platform/config/Config.py
@@ -174,7 +174,7 @@ class AutograderConfigurationSchema(BaseSchema[AutograderConfiguration]):
                     "autograder_version": And(str, Regex(r"\d+\.\d+\.\d+")),
                     "test_directory": And(str, os.path.exists),
                     "enforce_submission_limit": bool,
-                    Optional("submission_limit", default=1): And(int, lambda x: x >= 1),
+                    Optional("submission_limit", default=1000): And(int, lambda x: x >= 1),
                     Optional("take_highest", default=True): bool,
                     Optional("allow_extra_credit", default=False): bool,
                     "perfect_score": And(int, lambda x: x >= 1),

--- a/source/autograder_platform/config/Config.py
+++ b/source/autograder_platform/config/Config.py
@@ -174,7 +174,7 @@ class AutograderConfigurationSchema(BaseSchema[AutograderConfiguration]):
                     "autograder_version": And(str, Regex(r"\d+\.\d+\.\d+")),
                     "test_directory": And(str, os.path.exists),
                     "enforce_submission_limit": bool,
-                    Optional("submission_limit", default=1000): And(int, lambda x: x >= 1),
+                    Optional("submission_limit", default=1): And(int, lambda x: x >= 1),
                     Optional("take_highest", default=True): bool,
                     Optional("allow_extra_credit", default=False): bool,
                     "perfect_score": And(int, lambda x: x >= 1),

--- a/tests/cli_tests/testRunGradescope.py
+++ b/tests/cli_tests/testRunGradescope.py
@@ -149,8 +149,6 @@ class TestGradescopeUtils(unittest.TestCase):
         self.assertEqual(10, self.autograderResults["score"])
 
     def testInvalidPreviousSubmission(self):
-        # This is a fix for the broken behavoir that we see if GS crashes
-
         self.metadata["previous_submissions"].append({
             "results": {}
         })
@@ -166,6 +164,59 @@ class TestGradescopeUtils(unittest.TestCase):
         self.gradescopeCLI.config.config.submission_limit = 3
         self.gradescopeCLI.config.config.take_highest = True
 
+
+        self.gradescopeCLI.gradescope_post_processing(self.autograderResults)
+
+        self.assertEqual(10, self.autograderResults["score"])
+
+    def testInvalidSubmissionInSubset(self):
+        self.metadata["previous_submissions"].append({
+            "results": {}
+        })
+
+        self.autograderResults["score"] = 10
+
+        self.writeMetadata()
+
+        self.gradescopeCLI.config.config.submission_limit = 1
+        self.gradescopeCLI.config.config.take_highest = True
+
+        self.gradescopeCLI.gradescope_post_processing(self.autograderResults)
+
+        self.assertEqual(10, self.autograderResults["score"])
+
+    def testMissingScore(self):
+        del self.autograderResults["score"]
+
+        self.writeMetadata()
+
+        self.gradescopeCLI.config.config.submission_limit = 1
+        self.gradescopeCLI.config.config.take_highest = True
+
+        self.gradescopeCLI.gradescope_post_processing(self.autograderResults)
+
+        self.assertIn("Autograder run was INVALID", self.autograderResults["output"])
+
+    def testMissingMetadata(self):
+        self.gradescopeCLI.config.config.submission_limit = 1
+        self.gradescopeCLI.config.config.take_highest = True
+
+        self.gradescopeCLI.gradescope_post_processing(self.autograderResults)
+
+        self.assertIn("Autograder run was INVALID", self.autograderResults["output"])
+
+    def testIgnoreFailedRuns(self):
+        for _ in range(100):
+            self.metadata["previous_submissions"].append({
+                "results": {}
+            })
+
+        self.autograderResults["score"] = 10
+
+        self.writeMetadata()
+
+        self.gradescopeCLI.config.config.submission_limit = 1
+        self.gradescopeCLI.config.config.take_highest = True
 
         self.gradescopeCLI.gradescope_post_processing(self.autograderResults)
 

--- a/tests/cli_tests/testRunGradescope.py
+++ b/tests/cli_tests/testRunGradescope.py
@@ -28,6 +28,11 @@ class TestGradescopeUtils(unittest.TestCase):
         self.gradescopeCLI = GradescopeAutograderCLI()
 
         self.gradescopeCLI.config = mock.Mock()
+        self.gradescopeCLI.config.config.submission_limit = 3
+        self.gradescopeCLI.config.config.take_highest = True
+        self.gradescopeCLI.config.config.allow_extra_credit = False
+        self.gradescopeCLI.config.config.perfect_score = 10
+        self.gradescopeCLI.config.config.max_score = 10
         self.gradescopeCLI.arguments = mock.Mock()
         self.gradescopeCLI.arguments.metadata_path = self.METADATA_PATH
 
@@ -37,7 +42,7 @@ class TestGradescopeUtils(unittest.TestCase):
 
     def writeMetadata(self):
         with open(self.METADATA_PATH, 'w') as w:
-            json.dump(self.metadata, w)
+            json.dump(self.metadata, w)  # type: ignore
 
     def testNoPriorSubmissions(self):
         self.writeMetadata()
@@ -222,6 +227,77 @@ class TestGradescopeUtils(unittest.TestCase):
 
         self.assertEqual(10, self.autograderResults["score"])
 
+    def testDontEnforceSubmissionLimit(self):
+        for i in range(100):
+            self.metadata["previous_submissions"].append({
+                "results": {
+                    "score": i + 1
+                }
+            })
 
-    # TODO Add test for score greater than autograder score
-    # TODO Add test for not enforcing submission limit
+        self.autograderResults["score"] = 0
+
+        self.writeMetadata()
+
+        self.gradescopeCLI.config.config.submission_limit = 1
+        self.gradescopeCLI.config.config.enforce_submission_limit = False
+        self.gradescopeCLI.config.config.take_highest = True
+        self.gradescopeCLI.config.config.perfect_score = 100
+
+        self.gradescopeCLI.gradescope_post_processing(self.autograderResults)
+
+        self.assertEqual(100, self.autograderResults["score"])
+
+    def testDontTakeHighest(self):
+        self.metadata["previous_submissions"].append({
+            "results": {
+                "score": 10
+            }
+        })
+
+        self.autograderResults["score"] = 0
+        self.writeMetadata()
+
+        self.gradescopeCLI.config.config.enforce_submission_limit = False
+        self.gradescopeCLI.config.config.take_highest = False
+
+        self.gradescopeCLI.gradescope_post_processing(self.autograderResults)
+
+        self.assertEqual(0, self.autograderResults["score"])
+
+
+    def testExceedsPerfectScoreNoEC(self):
+        self.autograderResults["score"] = 11
+        self.writeMetadata()
+
+        self.gradescopeCLI.config.config.allow_extra_credit = False
+        self.gradescopeCLI.config.config.perfect_score = 10
+        self.gradescopeCLI.config.config.max_score = 15
+
+        self.gradescopeCLI.gradescope_post_processing(self.autograderResults)
+
+        self.assertEqual(10, self.autograderResults["score"])
+
+    def testExceedsPerfectScoreEC(self):
+        self.autograderResults["score"] = 11
+        self.writeMetadata()
+
+        self.gradescopeCLI.config.config.allow_extra_credit = True
+        self.gradescopeCLI.config.config.perfect_score = 10
+        self.gradescopeCLI.config.config.max_score = 15
+
+        self.gradescopeCLI.gradescope_post_processing(self.autograderResults)
+
+        self.assertEqual(11, self.autograderResults["score"])
+
+    def testExceedsMaxScoreEC(self):
+        self.autograderResults["score"] = 16
+        self.writeMetadata()
+
+        self.gradescopeCLI.config.config.allow_extra_credit = True
+        self.gradescopeCLI.config.config.perfect_score = 10
+        self.gradescopeCLI.config.config.max_score = 15
+
+        self.gradescopeCLI.gradescope_post_processing(self.autograderResults)
+
+        self.assertEqual(15, self.autograderResults["score"])


### PR DESCRIPTION
closes #116

closes #87

- Fixes post processing when only submission is missing a score
- Enforces score cap
- Ignores unscorable submissions
    - students can simply resubmit when GS fails to run and it won't count against them!
- Adds student facing error messages when submission is unscorable
